### PR TITLE
Dep update at 2018-12-17 22:00:48

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -53,12 +53,12 @@
   revision = "82935fac6c1a317907c8f43ed3f7f85ea844a78b"
 
 [[projects]]
-  digest = "1:82b912465c1da0668582a7d1117339c278e786c2536b3c3623029a0c7141c2d0"
+  digest = "1:84c28d9899cc4e00c38042d345cea8819275a5a62403a58530cac67022894776"
   name = "github.com/mattn/go-runewidth"
   packages = ["."]
   pruneopts = ""
-  revision = "ce7b0b5c7b45a81508558cd1dba6bb1e4ddb51bb"
-  version = "v0.0.3"
+  revision = "3ee7d812e62a0804a7d0a324e0249ca2db3476d3"
+  version = "v0.0.4"
 
 [[projects]]
   digest = "1:8bbdb2b3dce59271877770d6fe7dcbb8362438fa7d2e1e1f688e4bf2aac72706"


### PR DESCRIPTION
**Changed:**

* [github.com/mattn/go-runewidth](https://github.com/mattn/go-runewidth) [v0.0.3...v0.0.4](https://github.com/mattn/go-runewidth/compare/v0.0.3...v0.0.4)
